### PR TITLE
Historical data when symbol was restructured (renamed)

### DIFF
--- a/QuantConnect.AlphaVantage/AlphaVantageDataDownloader.cs
+++ b/QuantConnect.AlphaVantage/AlphaVantageDataDownloader.cs
@@ -164,7 +164,8 @@ namespace QuantConnect.Lean.DataSource.AlphaVantage
             }
 
             var request = new RestRequest("query", DataFormat.Json);
-            request.AddParameter("symbol", symbol.Value);
+            // Always obtain the most relevant ticker symbol based on the current time.
+            request.AddParameter("symbol", SecurityIdentifier.Ticker(dataDownloaderGetParameters.Symbol, DateTime.UtcNow));
             request.AddParameter("datatype", "csv");
 
             IEnumerable<TimeSeries> data;
@@ -206,7 +207,8 @@ namespace QuantConnect.Lean.DataSource.AlphaVantage
             request.AddParameter("function", "TIME_SERIES_DAILY");
 
             // The default output only includes 100 trading days of data. If we want need more, specify full output
-            if (GetBusinessDays(startUtc, endUtc, symbol) > 100)
+            // Compare with Today, because request doesn't contain specific DateTime range
+            if (GetBusinessDays(startUtc, DateTime.UtcNow, symbol) > 100)
             {
                 request.AddParameter("outputsize", "full");
             }

--- a/QuantConnect.AlphaVantage/AlphaVantageDataDownloader.cs
+++ b/QuantConnect.AlphaVantage/AlphaVantageDataDownloader.cs
@@ -48,22 +48,22 @@ namespace QuantConnect.Lean.DataSource.AlphaVantage
         /// <summary>
         /// Indicates whether the warning for invalid history <see cref="TickType"/> has been fired.
         /// </summary>
-        private bool _invalidHistoryDataTypeErrorFired;
+        private volatile bool _invalidHistoryDataTypeErrorFired;
 
         /// <summary>
         /// Indicates whether the warning for invalid <see cref="SecurityType"/> has been fired.
         /// </summary>
-        private bool _invalidSecurityTypeWarningFired;
+        private volatile bool _invalidSecurityTypeWarningFired;
 
         /// <summary>
         /// Indicates whether a warning for an invalid <see cref="Resolution"/> has been fired, where the resolution is neither daily nor minute-based.
         /// </summary>
-        private bool _invalidResolutionWarningFired;
+        private volatile bool _invalidResolutionWarningFired;
 
         /// <summary>
         /// Indicates whether a warning for an invalid start time has been fired, where the start time is greater than or equal to the end time in UTC.
         /// </summary>
-        private bool _invalidStartTimeErrorFired;
+        private volatile bool _invalidStartTimeErrorFired;
 
         /// <summary>
         /// Represents a mapping of symbols to their corresponding time zones for exchange information.
@@ -136,8 +136,8 @@ namespace QuantConnect.Lean.DataSource.AlphaVantage
             {
                 if (!_invalidStartTimeErrorFired)
                 {
-                    Log.Error($"{nameof(AlphaVantageDataDownloader)}.{nameof(Get)}:InvalidDateRange. The history request start date must precede the end date, no history returned");
                     _invalidStartTimeErrorFired = true;
+                    Log.Error($"{nameof(AlphaVantageDataDownloader)}.{nameof(Get)}:InvalidDateRange. The history request start date must precede the end date, no history returned");
                 }
                 return null;
             }
@@ -146,9 +146,9 @@ namespace QuantConnect.Lean.DataSource.AlphaVantage
             {
                 if (!_invalidHistoryDataTypeErrorFired)
                 {
+                    _invalidHistoryDataTypeErrorFired = true;
                     Log.Error($"{nameof(AlphaVantageDataDownloader)}.{nameof(Get)}: Not supported data type - {tickType}. " +
                         $"Currently available support only for historical of type - TradeBar");
-                    _invalidHistoryDataTypeErrorFired = true;
                 }
                 return null;
             }
@@ -157,8 +157,8 @@ namespace QuantConnect.Lean.DataSource.AlphaVantage
             {
                 if (!_invalidSecurityTypeWarningFired)
                 {
-                    Log.Trace($"{nameof(AlphaVantageDataDownloader)}.{nameof(Get)}: Unsupported SecurityType '{symbol.SecurityType}' for symbol '{symbol}'");
                     _invalidSecurityTypeWarningFired = true;
+                    Log.Trace($"{nameof(AlphaVantageDataDownloader)}.{nameof(Get)}: Unsupported SecurityType '{symbol.SecurityType}' for symbol '{symbol}'");
                 }
                 return null;
             }
@@ -167,7 +167,7 @@ namespace QuantConnect.Lean.DataSource.AlphaVantage
             request.AddParameter("symbol", symbol.Value);
             request.AddParameter("datatype", "csv");
 
-            IEnumerable<TimeSeries> data = null;
+            IEnumerable<TimeSeries> data;
             switch (resolution)
             {
                 case Resolution.Minute:
@@ -180,8 +180,8 @@ namespace QuantConnect.Lean.DataSource.AlphaVantage
                 default:
                     if (!_invalidResolutionWarningFired)
                     {
-                        Log.Trace($"{nameof(AlphaVantageDataDownloader)}.{resolution} resolution not supported by API.");
                         _invalidResolutionWarningFired = true;
+                        Log.Trace($"{nameof(AlphaVantageDataDownloader)}.{resolution} resolution not supported by API.");
                     }
                     return null;
             }


### PR DESCRIPTION
#### Description
This pull request introduces the implementation of historical data retrieval for equity securities from the Alpha Vantage data source. It includes the necessary functionalities to fetch historical data for a specified equity, enabling users to access past performance metrics.
**The current DataSource alway request historical data with actual ticker name.**
> For instance:
**You want to get all `META` (in past was `FB`), you need request to all data using `META` ticker.**

#### Related Issue
N/A

#### Related PR
- https://github.com/QuantConnect/Lean/pull/7826
- https://github.com/QuantConnect/Lean/pull/7845

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Historical data retrieval is crucial for various analytical and forecasting purposes, especially in financial domains. By implementing this feature, users will be able to analyze the historical performance of equity securities listed on Alpha Vantage. This functionality enhances the capabilities of our platform, providing valuable insights for traders, investors, and analysts.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Created comprehensive test cases covering different scenarios, including equities with alternative names.
- Tested the functionality with a variety of equities to ensure consistent and accurate historical data retrieval.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
